### PR TITLE
fix: defer reCAPTCHA load to renderReCaptcha with idle fallback for iframe compat

### DIFF
--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -28,16 +28,34 @@ define(
              */
             initialize: function () {
                 this._super();
-
-                this.attachFocusEvent();
+                this._apiLoaded = false;
             },
 
-            attachFocusEvent: function () {
-                const self = this, $parentForm = $('#' + this.getReCaptchaId() + '-container').parents('form');
+            /**
+             * Defers reCAPTCHA API loading until the form DOM exists.
+             * Loads on first form field focus, with an idle-callback fallback
+             * for iframes and programmatic-submit scenarios.
+             *
+             * @param {jQuery} $parentForm
+             * @private
+             */
+            _deferApiLoad: function ($parentForm) {
+                var self = this,
+                    load = function () {
+                        if (!self._apiLoaded) {
+                            self._apiLoaded = true;
+                            $parentForm.off('focus.recaptcha', 'input, select, textarea', load);
+                            self._loadApi();
+                        }
+                    };
 
-                $parentForm.one('focus', 'input, select, textarea', function () {
-                    self._loadApi();
-                });
+                $parentForm.one('focus.recaptcha', 'input, select, textarea', load);
+
+                if (window.requestIdleCallback) {
+                    window.requestIdleCallback(load, {timeout: 3000});
+                } else {
+                    setTimeout(load, 1000);
+                }
             },
 
             /**
@@ -213,10 +231,22 @@ define(
              * Render reCAPTCHA
              */
             renderReCaptcha: function () {
-                if (window.grecaptcha && window.grecaptcha.render) { // Check if reCAPTCHA is already loaded
+                var $wrapper = $('#' + this.getReCaptchaId() + '-wrapper'),
+                    $parentForm = $wrapper.parents('form');
+
+                if (!this._apiLoaded) {
+                    if ($parentForm.length) {
+                        this._deferApiLoad($parentForm);
+                    } else {
+                        this._apiLoaded = true;
+                        this._loadApi();
+                    }
+                }
+
+                if (window.grecaptcha && window.grecaptcha.render) {
                     this.initCaptcha();
-                } else { // Wait for reCAPTCHA to be loaded
-                    $(window).on('recaptchaapiready', function () {
+                } else {
+                    $(window).one('recaptchaapiready', function () {
                         this.initCaptcha();
                     }.bind(this));
                 }

--- a/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
+++ b/ReCaptchaFrontendUi/view/frontend/web/js/reCaptcha.js
@@ -235,7 +235,10 @@ define(
                     $parentForm = $wrapper.parents('form');
 
                 if (!this._apiLoaded) {
-                    if ($parentForm.length) {
+                    if (window.grecaptcha && window.grecaptcha.render) {
+                        // API already present, skip deferred load
+                        this._apiLoaded = true;
+                    } else if ($parentForm.length) {
                         this._deferApiLoad($parentForm);
                     } else {
                         this._apiLoaded = true;


### PR DESCRIPTION
   The reCAPTCHA deferred loading in #6 broke iframe-embedded payment forms (e.g. Braintree hosted fields) and had a DOM timing bug where the focus listener never actually attached.

This PR:

   - **Moves deferred load from `initialize()` to `renderReCaptcha()`** — the KO `afterRender` callback, where the form DOM actually exists
   - **Focus on form fields** triggers eager API load (preserves #6's performance goal)
   - **`requestIdleCallback` with 3s timeout** (or `setTimeout(1s)` fallback) ensures the API loads for iframes and no-focus scenarios
   - **Falls back to immediate load** when no parent `<form>` is found, instead of silently deadlocking
   - **Uses `$(window).one()`** for `recaptchaapiready` to prevent handler accumulation

   ### Problems with the previous approach (#6)

   1. `attachFocusEvent()` ran in `initialize()` before KO rendered the template
   2. Iframe-embedded fields (Braintree, PayPal hosted fields) never fire `focus` on the parent form
   3. `$(window).on('recaptchaapiready')` accumulated handlers on repeated `renderReCaptcha` calls (like `reCaptchaStorePickup`)

   ### Compatibility notes

   - **Checkout with iframe payment methods**: Should work — idle callback fires within 3s max
   - **Simple forms (contact, newsletter, login)**: Focus-based eager load still works as intended
   - **`reCaptchaStorePickup`**: `_apiLoaded` guard prevents double `_deferApiLoad`; `.one()` prevents handler leak
   - **`reCaptchaCheckout` clones**: Inherit `_apiLoaded` state correctly; no behavior change
   - **No parent form edge case**: Loads API immediately instead of permanent deadlock

   Ref: https://github.com/mage-os/mageos-security-package/pull/6#issuecomment-4076372462

   ## Test plan

   - [ ] Enable reCAPTCHA (any version) for a frontend form (contact, newsletter, login)
   - [ ] Verify reCAPTCHA script is NOT loaded on initial page load (check Network tab)
   - [ ] Click into a form field — verify reCAPTCHA loads and widget appears
   - [ ] Reload page, do NOT interact — verify reCAPTCHA loads within ~3 seconds via idle callback
   - [ ] Test checkout with Braintree (or other iframe-based payment) — verify reCAPTCHA loads and Place Order works
   - [ ] Test store pickup reCAPTCHA — verify widget renders on address change without console errors
   - [ ] Test with ad blocker blocking Google reCAPTCHA domain — verify form behavior is no worse than before